### PR TITLE
Fix user utility imports and manager password handling

### DIFF
--- a/cargo/accounts/models.py
+++ b/cargo/accounts/models.py
@@ -5,15 +5,18 @@ from accounts.utils import generate_next_auth_key
 
 
 class CustomUserManager(BaseUserManager):
-    def create_user(self, gmail, phone_number, first_name, last_name):
+    def create_user(self, gmail, phone_number, first_name, last_name, password=None):
+        """Create and return a user with the given credentials."""
         if not gmail:
             raise ValueError("The Gmail field is required")
         user = self.model(
             gmail=self.normalize_email(gmail),
             phone_number=phone_number,
             first_name=first_name,
-            last_name=last_name
+            last_name=last_name,
         )
+        # ``set_password`` correctly handles ``None`` by setting an unusable
+        # password, so we can pass it through directly.
         user.set_password(password)
         user.save(using=self._db)
         return user

--- a/cargo/accounts/utils.py
+++ b/cargo/accounts/utils.py
@@ -1,12 +1,19 @@
 # auth_key_generator.py
+from django.contrib.auth import get_user_model
 from django.db import transaction
-from models import CustomUser
 
 
 def generate_next_auth_key():
+    """Return the next unique auth key.
+
+    Using ``get_user_model`` avoids a direct import of ``CustomUser`` which
+    would otherwise create a circular import between the model and this
+    utility module.
+    """
+    user_model = get_user_model()
     with transaction.atomic():
         # Блокируем таблицу для предотвращения race condition
-        last_user = CustomUser.objects.select_for_update().order_by('-auth_key').first()
+        last_user = user_model.objects.select_for_update().order_by('-auth_key').first()
 
         if not last_user:
             return 'C0001'


### PR DESCRIPTION
## Summary
- avoid circular imports by using `get_user_model` in auth key generator
- ensure `CustomUserManager.create_user` accepts and sets passwords

## Testing
- `pytest`
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6892ebaca4c8832e8f713e198fcfafad