### PR TITLE
Add styled login and registration pages

### DIFF
--- a/cargo/accounts/views.py
+++ b/cargo/accounts/views.py
@@ -48,7 +48,7 @@ def login_view(request):
             user = authenticate(request, username=email, password=password)
             if user is not None:
                 login(request, user)
-                return redirect('base')
+                return redirect('home')
             else:
                 form.add_error(None, 'Неверный email или пароль.')
     else:

--- a/cargo/templates/accounts/login.html
+++ b/cargo/templates/accounts/login.html
@@ -2,32 +2,30 @@
 {% load crispy_forms_tags %}
 
 {% block content %}
-    <div class="mask d-flex align-items-center h-100 gradient-custom-3">
-        <div class="container h-100 mt-5 p-5" >
-            <div class="d-flex justify-content-center align-items-center container">
-                <div class="col-12 col-md-9 col-lg-7 col-xl-6">
-                        <div class="card text-black" style="border-radius: 15px;">
-                                <div class="card-body p-5">
-                                        <h2 class="m-06">Авторизация</h2>
-                                        <form method="post">
-                                            {% csrf_token %}
-                                             <div data-mdb-input-init class="form-outline mb-4">
-                                            {{ form | crispy }}
-                                                 <label class="form-label" for="form3Example1cg"></label>
-                                             </div>
-                                            <input type="submit" class="btn btn-success btn-block btn-lg gradient-custom-4 text-body"
-                                                   value="Войти"/>
-                                        </form>
-                                        <p class="mt-3 mobile-text">Нет аккаунта? <a
-                                                href="{% url 'register' %}">Регистрация</a>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+<div class="mask d-flex align-items-center h-100 gradient-custom-3">
+  <div class="container h-100 mt-5 p-5">
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-9 col-lg-7 col-xl-6">
+        <div class="card text-black" style="border-radius: 15px;">
+          <div class="card-body p-5">
+            <h2 class="text-center mb-4">Авторизация</h2>
+            <form method="post">
+              {% csrf_token %}
+              {{ form|crispy }}
+              <div class="d-grid">
+                <button type="submit" class="btn btn-success btn-block btn-lg gradient-custom-4 text-body">
+                  Войти
+                </button>
+              </div>
+            </form>
+            <p class="mt-3 text-center">
+              Нет аккаунта? <a href="{% url 'register' %}">Регистрация</a>
+            </p>
+          </div>
         </div>
-        </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
+

--- a/cargo/templates/accounts/register.html
+++ b/cargo/templates/accounts/register.html
@@ -1,33 +1,31 @@
 {% extends "base.html" %}
-
 {% load crispy_forms_tags %}
+
 {% block content %}
-    <div class="mask d-flex align-items-center h-100 gradient-custom-3">
-        <div class="container h-100 mt-5 p-5" >
-            <div class="d-flex justify-content-center align-items-center container">
-                <div class="col-12 col-md-9 col-lg-7 col-xl-6">
-                        <div class="card text-black" style="border-radius: 15px;">
-                                <div class="card-body p-5">
-                                        <h2 class="m-06">Регистрация</h2>
-                                        <form method="post">
-                                            {% csrf_token %}
-                                             <div data-mdb-input-init class="form-outline mb-4">
-                                            {{ form | crispy }}
-                                                 <label class="form-label" for="form3Example1cg"></label>
-                                             </div>
-                                            <input type="submit" class="btn btn-success btn-block btn-lg gradient-custom-4 text-body"
-                                                   value="Зарегистрироваться"/>
-                                        </form>
-                                        <p class="mt-3 mobile-text">Уже есть аккаунт? <a
-                                                href="{% url 'login' %}">Вход</a>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+<div class="mask d-flex align-items-center h-100 gradient-custom-3">
+  <div class="container h-100 mt-5 p-5">
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-9 col-lg-7 col-xl-6">
+        <div class="card text-black" style="border-radius: 15px;">
+          <div class="card-body p-5">
+            <h2 class="text-center mb-4">Регистрация</h2>
+            <form method="post">
+              {% csrf_token %}
+              {{ form|crispy }}
+              <div class="d-grid">
+                <button type="submit" class="btn btn-success btn-block btn-lg gradient-custom-4 text-body">
+                  Зарегистрироваться
+                </button>
+              </div>
+            </form>
+            <p class="mt-3 text-center">
+              Уже есть аккаунт? <a href="{% url 'login' %}">Вход</a>
+            </p>
+          </div>
         </div>
-        </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- restyle login template with Bootstrap card and crispy form
- restyle registration template to match site design
- fix login view redirect to home

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_6892eed62c08832e8dea26f55fdb605f