### PR TITLE
Add shipment cost calculator page

### DIFF
--- a/cargo/templates/tracker/calculator.html
+++ b/cargo/templates/tracker/calculator.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+    <div class="mask d-flex align-items-center h-100 gradient-custom-3">
+        <div class="container h-100 mt-5 p-5">
+            <div class="d-flex justify-content-center align-items-center container">
+                <div class="col-12 col-md-9 col-lg-7 col-xl-6">
+                    <div class="card text-black" style="border-radius: 15px;">
+                        <div class="card-body p-5">
+                            <h2 class="m-06">Калькулятор стоимости</h2>
+                            <form method="post">
+                                {% csrf_token %}
+                                <div data-mdb-input-init class="form-outline mb-4">
+                                    {{ form|crispy }}
+                                </div>
+                                <input type="submit" class="btn btn-success btn-block btn-lg gradient-custom-4 text-body" value="Рассчитать"/>
+                            </form>
+                            {% if price is not None %}
+                                <div class="mt-4">
+                                    <h4>Стоимость: {{ price }} $</h4>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/cargo/tracker/forms.py
+++ b/cargo/tracker/forms.py
@@ -5,6 +5,15 @@ class CargoForm(forms.Form):
     track_code = forms.CharField(label='Track Code', max_length=40, min_length=8)
 
 
+class CalculatorForm(forms.Form):
+    """Simple calculator form for cargo dimensions and weight."""
+
+    height = forms.FloatField(label='Height (cm)', min_value=0)
+    width = forms.FloatField(label='Width (cm)', min_value=0)
+    length = forms.FloatField(label='Length (cm)', min_value=0)
+    weight = forms.FloatField(label='Weight (kg)', min_value=0)
+
+
 class StatusForm(forms.Form):
     status = forms.CharField(label='Status', max_length=40, min_length=8)
     datetime = forms.CharField(label='Date/Time', max_length=40, min_length=8)

--- a/cargo/tracker/urls.py
+++ b/cargo/tracker/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import track, home
+from .views import track, home, calculator
 
 urlpatterns = [
     path('track/', track, name='track'),
+    path('calculator/', calculator, name='calculator'),
     path('', home, name='home'),
 ]

--- a/cargo/tracker/views.py
+++ b/cargo/tracker/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
-from tracker.forms import CargoForm
+from tracker.forms import CargoForm, CalculatorForm
 from tracker.services import Ship24Service
 
 
@@ -23,3 +23,20 @@ def track(request):
 
 def home(request):
     return render(request, 'main.html')
+
+
+def calculator(request):
+    """Calculate shipment cost based on weight."""
+    price = None
+    if request.method == 'POST':
+        form = CalculatorForm(request.POST)
+        if form.is_valid():
+            weight = form.cleaned_data['weight']
+            price = weight * 3.2
+    else:
+        form = CalculatorForm()
+    return render(
+        request,
+        'templates/tracker/calculator.html',
+        {'form': form, 'price': price},
+    )


### PR DESCRIPTION
## Summary
- add calculator form to input package dimensions and weight
- compute cost based on weight and show result
- expose calculator at `/calculator/`

## Testing
- `python cargo/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6892ef6759f8832ead74d131b042b3c9